### PR TITLE
Fix Natura berry bush sieving

### DIFF
--- a/exaliquo/bridges/Natura/Sieving.java
+++ b/exaliquo/bridges/Natura/Sieving.java
@@ -35,10 +35,10 @@ public class Sieving
 			}
 			if (Configurations.sieveBerryBushes)
 			{
-				register(topiary, 0, getIDs(Info.good), 0, 64);
-				register(topiary, 0, getIDs(Info.good), 1, 64);
-				register(topiary, 0, getIDs(Info.good), 2, 64);
-				register(topiary, 0, getIDs(Info.good), 3, 64);
+				register(topiary, i, getIDs(Info.good), 0, 64);
+				register(topiary, i, getIDs(Info.good), 1, 64);
+				register(topiary, i, getIDs(Info.good), 2, 64);
+				register(topiary, i, getIDs(Info.good), 3, 64);
 			}
 		}
 		if (Configurations.sieveNetherTrees)


### PR DESCRIPTION
The berry bushes were added to the sieve registry multiple times instead of being added for the different topiary-type blocks.
