### PR TITLE
Fix CobaltSand.name in en_US.lang

### DIFF
--- a/resources/assets/exaliquo/lang/en_US.lang
+++ b/resources/assets/exaliquo/lang/en_US.lang
@@ -145,7 +145,7 @@ item.ExAliquo.ZincSand.name=Crushed Zinc Ore
 item.ExAliquo.ZincDust.name=Pulverized Zinc Ore
 #OreBlocks
 block.ExAliquo.CobaltGravel.name=Cobalt Ore Gravel
-block.ExAliquo.CobaltSand.name=Cobalt Ore Ore Dust
+block.ExAliquo.CobaltSand.name=Cobalt Ore Sand
 block.ExAliquo.CobaltDust.name=Cobalt Ore Dust
 block.ExAliquo.ArditeGravel.name=Ardite Ore Gravel
 block.ExAliquo.ArditeSand.name=Ardite Ore Sand


### PR DESCRIPTION
Fixed a misleading typo.

Noticed while programming Steve's Inventory Manager playing Crash Landing :)
